### PR TITLE
Add Cloudinary storage configuration

### DIFF
--- a/lumiere_glamour/settings.py
+++ b/lumiere_glamour/settings.py
@@ -151,6 +151,13 @@ CLOUDINARY_CLOUD_NAME = os.environ.get("CLOUDINARY_CLOUD_NAME")
 CLOUDINARY_API_KEY = os.environ.get("CLOUDINARY_API_KEY")
 CLOUDINARY_API_SECRET = os.environ.get("CLOUDINARY_API_SECRET")
 
+CLOUDINARY_STORAGE = {
+    "CLOUD_NAME": CLOUDINARY_CLOUD_NAME,
+    "API_KEY": CLOUDINARY_API_KEY,
+    "API_SECRET": CLOUDINARY_API_SECRET,
+    "SECURE": True,
+}
+
 # Configura Cloudinary como el sistema de almacenamiento por defecto para archivos de medios
 DEFAULT_FILE_STORAGE = "cloudinary_storage.storage.MediaCloudinaryStorage"
 


### PR DESCRIPTION
## Summary
- add Cloudinary storage settings for secure media URLs

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_68939c92e354832fbde5ed125befb9ee