### PR TITLE
Add quantity controls for product pages

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -357,6 +357,40 @@ function setupMoreColorsButton() {
     });
 }
 
+// Controlar incrementos y decrementos de cantidad
+function setupQuantityControls() {
+    const quantityInput = document.getElementById('quantity');
+    const decreaseBtn = document.getElementById('quantity-decrease');
+    const increaseBtn = document.getElementById('quantity-increase');
+
+    if (!quantityInput) return;
+
+    const sanitize = () => {
+        let value = parseInt(quantityInput.value, 10);
+        if (isNaN(value) || value < 1) {
+            value = 1;
+        }
+        quantityInput.value = value;
+        return value;
+    };
+
+    if (decreaseBtn) {
+        decreaseBtn.addEventListener('click', () => {
+            const value = sanitize() - 1;
+            quantityInput.value = value < 1 ? 1 : value;
+        });
+    }
+
+    if (increaseBtn) {
+        increaseBtn.addEventListener('click', () => {
+            const value = sanitize() + 1;
+            quantityInput.value = value;
+        });
+    }
+
+    quantityInput.addEventListener('change', sanitize);
+}
+
 // Lógica para añadir al carrito (unificada para todos los botones .btn-agregar-carrito)
 function setupAddToCartButtons() {
     const botonesAgregar = document.querySelectorAll(".btn-agregar-carrito");
@@ -375,14 +409,15 @@ function setupAddToCartButtons() {
             if (parentContainer) {
                 const quantityInput = parentContainer.querySelector("input[type='number']");
                 if (quantityInput) {
-                    quantity = parseInt(quantityInput.value);
-                    if (isNaN(quantity) || quantity <= 0) {
+                    quantity = parseInt(quantityInput.value, 10);
+                    if (isNaN(quantity) || quantity < 1) {
                         quantity = 1;
                     }
+                    quantityInput.value = quantity;
                 }
             }
 
-            if (quantity > 0) {
+            if (quantity >= 1) {
                 fetch("/agregar-al-carrito/", {
                     method: "POST",
                     headers: {
@@ -630,6 +665,7 @@ document.addEventListener("DOMContentLoaded", function () {
     setupWhatsappButtons();
     setupColorOptions();
     setupMoreColorsButton();
+    setupQuantityControls();
     setupAddToCartButtons();
 
     // --- Miniaturas que cambian la imagen principal (detalle de producto) ---

--- a/store/templates/store/producto.html
+++ b/store/templates/store/producto.html
@@ -81,11 +81,15 @@
                 </p>
                 <div class="flex items-center space-x-4 mb-8">
                     <label for="quantity" class="text-lg font-medium text-gray-700">Cantidad:</label>
-                    <input type="number"
-                           id="quantity"
-                           value="1"
-                           min="1"
-                           class="w-20 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-500 text-center">
+                    <div class="flex items-center border border-gray-300 rounded-md">
+                        <button type="button" id="quantity-decrease" class="px-3 py-2 text-gray-700">-</button>
+                        <input type="number"
+                               id="quantity"
+                               value="1"
+                               min="1"
+                               class="w-20 px-3 py-2 text-center border-l border-r border-gray-300 focus:outline-none focus:ring-2 focus:ring-pink-500">
+                        <button type="button" id="quantity-increase" class="px-3 py-2 text-gray-700">+</button>
+                    </div>
                 </div>
                 <!-- Lógica de Variaciones (Colores/Tonos) -->
                 {% if variaciones %}


### PR DESCRIPTION
## Summary
- add plus/minus buttons around quantity input on product pages
- update JS to handle quantity increment/decrement and validation
- ensure cart requests use sanitized quantity value

## Testing
- `python manage.py test`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6893b13dade4832fb63a763ca5f63ea7