### PR TITLE
feat: improve product color selection

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -313,8 +313,9 @@ function setupColorOptions() {
             const selectedVariantId = this.dataset.variantId;
             const selectedColorName = this.dataset.colorName;
             const selectedVariantImage = this.dataset.variantImage;
-            const selectedVariantPrice = this.dataset.variantPrice;
+            const selectedVariantPrice = parseFloat(this.dataset.variantPrice);
 
+            // Imagen y precio para listados de productos
             const productImage = productId ? parentProductDiv.querySelector(`#product-image-${productId}`) : null;
             if (productImage) {
                 productImage.src = selectedVariantImage;
@@ -325,14 +326,34 @@ function setupColorOptions() {
                 productPriceSpan.textContent = formatPriceForDisplay(selectedVariantPrice);
             }
 
-            if (parentProductDiv) {
+            // Imagen y precio principales en la vista de producto
+            if (!parentProductDiv) {
+                const mainImage = document.getElementById('main-product-image');
+                if (mainImage) {
+                    mainImage.src = selectedVariantImage;
+                }
+
+                const mainPrice = document.getElementById('main-product-price');
+                if (mainPrice) {
+                    mainPrice.textContent = formatPriceForDisplay(selectedVariantPrice);
+                }
+
+                const colorNameDisplay = document.getElementById('selected-color-name');
+                if (colorNameDisplay) {
+                    colorNameDisplay.textContent = selectedColorName;
+                }
+
+                document.querySelectorAll('.color-option').forEach(option => {
+                    option.classList.remove('selected', 'ring-2', 'ring-pink-500', 'border-pink-500');
+                });
+            } else {
                 parentProductDiv.querySelectorAll('.color-option').forEach(option => {
-                    option.classList.remove('selected');
+                    option.classList.remove('selected', 'ring-2', 'ring-pink-500', 'border-pink-500');
                 });
             }
-            this.classList.add('selected');
+            this.classList.add('selected', 'ring-2', 'ring-pink-500', 'border-pink-500');
 
-            const addToCartButton = parentProductDiv ? parentProductDiv.querySelector('.btn-agregar-carrito') : null;
+            const addToCartButton = parentProductDiv ? parentProductDiv.querySelector('.btn-agregar-carrito') : document.querySelector('.btn-agregar-carrito');
             if (addToCartButton) {
                 addToCartButton.dataset.selectedVariantId = selectedVariantId;
                 addToCartButton.dataset.productPrice = selectedVariantPrice;

--- a/store/templates/store/producto.html
+++ b/store/templates/store/producto.html
@@ -70,7 +70,7 @@
                 </div>
                 <div class="flex items-baseline mb-4">
                     {# Mostrar el precio final del producto #}
-                    <span class="text-5xl font-extrabold text-pink-600 mr-4">${{ producto.get_precio_final|floatformat:0|intcomma }}</span>
+                    <span id="main-product-price" class="text-5xl font-extrabold text-pink-600 mr-4">${{ producto.get_precio_final|floatformat:0|intcomma }}</span>
                     {# Mostrar el precio original tachado si hay descuento #}
                     {% if producto.descuento > 0 %}
                         <span class="text-xl text-gray-500 line-through">${{ producto.precio|floatformat:0|intcomma }}</span>
@@ -98,7 +98,7 @@
                                 <p class="font-medium text-gray-700 mb-2">{{ tipo.grouper }}:</p>
                                 <div class="flex flex-wrap gap-2">
                                     {% for var in tipo.list %}
-                                        <button class="color-option relative w-10 h-10 rounded-full border-2 border-gray-300 flex items-center justify-center cursor-pointer hover:border-pink-500 transition-all duration-200 {% if forloop.first %}selected{% endif %}"
+                                        <button class="color-option relative w-10 h-10 rounded-full border-2 border-gray-300 flex items-center justify-center cursor-pointer hover:border-pink-500 transition-all duration-200 {% if forloop.first %}selected ring-2 ring-pink-500 border-pink-500{% endif %}"
                                                 style="{% if var.color_hex %}background-color: {{ var.color_hex }};
                                                        {% else %}background-color: #f0f0f0;
                                                        {% endif %}"
@@ -111,14 +111,12 @@
                                             {% if not var.color_hex %}
                                                 <span class="text-xs font-semibold text-gray-800">{{ var.valor|slice:":2" }}</span>
                                             {% endif %}
-                                            {% if forloop.first %}
-                                                <i class="fas fa-check-circle absolute -bottom-1 -right-1 text-pink-600 bg-white rounded-full"></i>
-                                            {% endif %}
                                         </button>
                                     {% endfor %}
                                 </div>
                             </div>
                         {% endfor %}
+                        <p id="selected-color-display" class="mt-2 text-gray-700">Color seleccionado: <span id="selected-color-name">{{ variaciones.first.color|default:variaciones.first.valor }}</span></p>
                     </div>
                 {% endif %}
                 <!-- Botón Añadir al Carrito - Ahora con clase 'btn-agregar-carrito' -->


### PR DESCRIPTION
## Summary
- update color-option handler to refresh main image and price and highlight selected color
- show selected color name in product view

## Testing
- `python manage.py test`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6893b1429b38832fbf8896544ea4d39d