### PR TITLE
Improve favorite handling

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -653,13 +653,8 @@ function renderFavoritesFromLocalStorage() {
         .then(res => res.json())
         .then(data => {
             container.innerHTML = "";
-
-            const productosMap = new Map();
             data.productos.forEach(prod => {
-data.productos.forEach(prod => {
-    container.insertAdjacentHTML('beforeend', prod.html);
-});
-
+                container.insertAdjacentHTML('beforeend', prod.html);
             });
             updateFavoritesView();
         })
@@ -802,7 +797,19 @@ document.addEventListener("click", (event) => {
 
         const favContainer = document.getElementById("favoritos-container");
         if (favContainer) {
-            renderFavoritesFromLocalStorage();
+            const card = btn.closest(".product-card");
+            if (card) {
+                card.classList.add("opacity-0", "scale-95", "transition");
+                card.addEventListener(
+                    "transitionend",
+                    () => {
+                        renderFavoritesFromLocalStorage();
+                    },
+                    { once: true }
+                );
+            } else {
+                renderFavoritesFromLocalStorage();
+            }
         }
     }
 });


### PR DESCRIPTION
## Summary
- animate favorite removal before re-rendering
- render favorites with a single loop

## Testing
- `python manage.py test`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6893c3c16e78832f881633e438f8853c