### PR TITLE
Animate favorite card removal

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -796,20 +796,18 @@ document.addEventListener("click", (event) => {
         updateFavoritesView(); // 🔹 Para refrescar la página de favoritos
 
         const favContainer = document.getElementById("favoritos-container");
-        if (favContainer) {
-            const card = btn.closest(".product-card");
-            if (card) {
-                card.classList.add("opacity-0", "scale-95", "transition");
-                card.addEventListener(
-                    "transitionend",
-                    () => {
-                        renderFavoritesFromLocalStorage();
-                    },
-                    { once: true }
-                );
-            } else {
-                renderFavoritesFromLocalStorage();
-            }
+        const card = btn.closest(".product-card");
+        if (favContainer && card) {
+            card.classList.add("opacity-0", "scale-95", "transition");
+            card.addEventListener(
+                "transitionend",
+                () => {
+                    renderFavoritesFromLocalStorage();
+                },
+                { once: true }
+            );
+        } else {
+            renderFavoritesFromLocalStorage();
         }
     }
 });


### PR DESCRIPTION
## Summary
- Animate favorite card disappearance before re-rendering

## Testing
- `npm test` *(fails: Error: no test specified)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_b_6893c9163ef4832f94928ca37c3025a5