### PR TITLE
fix: render favorites using server HTML

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -660,7 +660,7 @@ function renderFavoritesFromLocalStorage() {
         })
         .catch(err => {
             console.error("Error cargando favoritos:", err);
-            container.innerHTML = "<p class='text-center text-red-500 py-8'>Error al cargar favoritos.</p>";
+            container.innerHTML = "<p class='text-center text-gray-500 py-8'>No tienes productos en favoritos.</p>";
         });
 }
 


### PR DESCRIPTION
## Summary
- render favorites using `/api/favoritos` and server-provided HTML
- show empty favorites message on load errors and refresh favorite state

## Testing
- `python manage.py test` *(fails: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6893c9185d20832f81222b08619dce41