### PR TITLE
Handle missing gallery images in get_primary_image_url

### DIFF
--- a/store/models.py
+++ b/store/models.py
@@ -198,10 +198,10 @@ class Producto(models.Model):
         """
         if self.imagen:
             return self.imagen.url
-        elif self.images.exists():
-            return self.images.first().image.url
-        else:
-            return static("img/sin_imagen.jpg")
+        first_image = self.images.first()
+        if first_image and first_image.image:
+            return first_image.image.url
+        return static("img/sin_imagen.jpg")
 
     def get_badge_class(self):
         """


### PR DESCRIPTION
## Summary
- safeguard gallery image lookup by checking for first image and image file before returning URL

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_6893d5c2bd94832fb540ef20bed3cd09