### PR TITLE
Condicionar uso de Cloudinary

### DIFF
--- a/lumiere_glamour/settings.py
+++ b/lumiere_glamour/settings.py
@@ -151,18 +151,23 @@ CLOUDINARY_CLOUD_NAME = os.environ.get("CLOUDINARY_CLOUD_NAME")
 CLOUDINARY_API_KEY = os.environ.get("CLOUDINARY_API_KEY")
 CLOUDINARY_API_SECRET = os.environ.get("CLOUDINARY_API_SECRET")
 
-CLOUDINARY_STORAGE = {
-    "CLOUD_NAME": CLOUDINARY_CLOUD_NAME,
-    "API_KEY": CLOUDINARY_API_KEY,
-    "API_SECRET": CLOUDINARY_API_SECRET,
-    "SECURE": True,
-}
+if (
+    CLOUDINARY_CLOUD_NAME
+    and CLOUDINARY_API_KEY
+    and CLOUDINARY_API_SECRET
+):
+    CLOUDINARY_STORAGE = {
+        "CLOUD_NAME": CLOUDINARY_CLOUD_NAME,
+        "API_KEY": CLOUDINARY_API_KEY,
+        "API_SECRET": CLOUDINARY_API_SECRET,
+        "SECURE": True,
+    }
+    # Configura Cloudinary como el sistema de almacenamiento por defecto para archivos de medios
+    DEFAULT_FILE_STORAGE = "cloudinary_storage.storage.MediaCloudinaryStorage"
+else:
+    # Si faltan las credenciales de Cloudinary, usa el sistema de archivos local
+    DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
 
-# Configura Cloudinary como el sistema de almacenamiento por defecto para archivos de medios
-DEFAULT_FILE_STORAGE = "cloudinary_storage.storage.MediaCloudinaryStorage"
-
-# MEDIA_URL y MEDIA_ROOT aún son útiles para referencia o desarrollo local,
-# pero Cloudinary gestionará el almacenamiento real en producción.
 MEDIA_URL = "/media/"
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 


### PR DESCRIPTION
## Summary
- Cambia la configuración de almacenamiento de archivos para usar Cloudinary solo si las variables de entorno necesarias están presentes

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_6893d5c1844c832fba89df742601f7eb