### PR TITLE
Use dynamic placeholder image

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -83,7 +83,7 @@ function cargarCarritoLocal() {
         window.cart.forEach(item => {
             item.quantity = (typeof item.quantity === 'number' && !isNaN(item.quantity)) ? item.quantity : 1;
             item.price = parseFloat(item.price) || 0;
-            item.imageUrl = item.imageUrl || window.placeholderImageUrl || '/static/img/sin_imagen.jpg';
+            item.imageUrl = item.imageUrl || window.placeholderImageUrl;
         });
     } else {
         window.cart = [];
@@ -146,13 +146,13 @@ function renderCartItems() {
         window.cart.forEach((item, index) => {
             const itemPrice = parseFloat(item.price) || 0;
             const itemQuantity = (typeof item.quantity === 'number' && !isNaN(item.quantity)) ? item.quantity : 1;
-            const imageUrlToDisplay = item.imageUrl || window.placeholderImageUrl || '/static/img/sin_imagen.jpg';
+            const imageUrlToDisplay = item.imageUrl || window.placeholderImageUrl;
             const subtotalItem = itemPrice * itemQuantity;
             total += subtotalItem;
 
             html += `
                 <div class="flex items-center justify-between py-2 border-b border-gray-100">
-                    <img src="${imageUrlToDisplay}" alt="${item.name}" class="w-16 h-16 object-cover rounded-md mr-3" onerror="this.onerror=null;this.src='${window.placeholderImageUrl || '/static/img/sin_imagen.jpg'}';">
+                    <img src="${imageUrlToDisplay}" alt="${item.name}" class="w-16 h-16 object-cover rounded-md mr-3" onerror="this.onerror=null;this.src='${window.placeholderImageUrl}';">
                     <div class="flex-1 min-w-0">
                         <p class="font-semibold text-gray-800">${item.name}</p>
                         ${item.color && item.color !== 'N/A' ? `<p class="text-sm text-gray-600">Color: ${item.color}</p>` : ''}

--- a/store/templates/store/components/product_card.html
+++ b/store/templates/store/components/product_card.html
@@ -76,7 +76,7 @@
                 data-product-name="{{ producto.nombre }}"
                 data-product-price="{{ producto.get_precio_final|floatformat:2 }}"
                 data-selected-variant-id="{% if producto.variaciones.exists %}{{ producto.variaciones.first.id }}{% else %}{{ producto.id }}{% endif %}"
-                data-product-image-url="{{ producto.get_primary_image_url|default:'/static/img/sin_imagen.jpg' }}"
+                data-product-image-url="{% if producto.get_primary_image_url %}{{ producto.get_primary_image_url }}{% else %}{% static 'img/sin_imagen.jpg' %}{% endif %}"
                 aria-label="Añadir {{ producto.nombre }} al carrito"
                 title="Añadir al carrito">
             <i class="fas fa-shopping-cart text-base"></i>

--- a/store/views.py
+++ b/store/views.py
@@ -8,6 +8,7 @@ from django.shortcuts import get_object_or_404, render, redirect
 from django.views.generic import ListView  # Importa ListView
 from django.core.cache import cache
 from django.template.loader import render_to_string
+from django.templatetags.static import static
 
 # Asegúrate de importar Producto, Categoria, Variacion y Favorito
 from .models import (
@@ -767,7 +768,7 @@ def api_favoritos(request):
             "id": p.id,
             "nombre": p.nombre,
             "precio": f"${p.get_precio_final():,.0f}",
-            "imagen": p.get_primary_image_url() or "/static/img/sin_imagen.jpg",
+            "imagen": p.get_primary_image_url() or static("img/sin_imagen.jpg"),
             "url": p.get_absolute_url() if hasattr(p, "get_absolute_url") else f"/producto/{p.id}/",
         }
         if include_html:


### PR DESCRIPTION
## Summary
- Replace hardcoded placeholder path in product cards with `{% static 'img/sin_imagen.jpg' %}` fallback
- Serve default images via Django's `static()` helper in favorite API
- Centralize placeholder image usage in `main.js` through global variable

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.9.0)*

------
https://chatgpt.com/codex/tasks/task_b_6893d5bfe1b4832fa9eb9afb33b62ebd