### PR TITLE
Serve media files from filesystem when Cloudinary disabled

### DIFF
--- a/lumiere_glamour/urls.py
+++ b/lumiere_glamour/urls.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
+from django.views.static import serve
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -12,3 +13,16 @@ urlpatterns = [
 # Para servir archivos multimedia (como imágenes) en modo desarrollo
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+if (
+    not settings.DEBUG
+    and settings.DEFAULT_FILE_STORAGE
+    == "django.core.files.storage.FileSystemStorage"
+):
+    urlpatterns += [
+        path(
+            f"{settings.MEDIA_URL.lstrip('/')}" + "<path:path>",
+            serve,
+            {"document_root": settings.MEDIA_ROOT},
+        )
+    ]


### PR DESCRIPTION
## Summary
- fallback to serving media with Django when DEBUG is off and using local file storage

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.9.0)*
- `python manage.py test` *(fails: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_b_6893d93fe50c832f814f0e0dc4c461f2