### PR TITLE
Ajusta ancho de enlaces de categorías

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -295,7 +295,7 @@
   text-decoration: none;
   color: inherit;
   transition: transform 0.3s ease;
-  width: 100%;
+  width: auto;
   padding: 0.5rem;
 }
 
@@ -335,6 +335,12 @@
   font-size: 0.875rem;
   font-weight: 500;
   text-align: center;
+}
+
+@media (max-width: 768px) {
+  .category-circle-link {
+    width: 100%;
+  }
 }
 
 /* Puedes añadir un estilo para un placeholder si no hay imagen */

--- a/store/templates/store/index.html
+++ b/store/templates/store/index.html
@@ -98,7 +98,7 @@
                     </div>
                 </div>
                 {# Cuadrícula de Categorías (solo para tablet y escritorio) #}
-                <div class="hidden md:flex flex-wrap justify-center gap-6 sm:gap-8">
+                <div class="hidden md:grid md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 gap-6 sm:gap-8 place-items-center">
                     {% for categoria in categorias_principales %}
                         <a href="{% url 'categoria' categoria.slug %}"
                            class="category-circle-link flex flex-col items-center text-center group">


### PR DESCRIPTION
## Summary
- Permite que los enlaces de categorías no ocupen todo el ancho y agrega regla responsiva para móviles
- Distribuye las categorías en una rejilla adaptable en pantallas grandes

## Testing
- ❌ `python manage.py test` (missing Django)


------
https://chatgpt.com/codex/tasks/task_b_68a3d22c88b8832fbb2185f690126a36